### PR TITLE
Feature/user management

### DIFF
--- a/cmd/copsctl/namespace.go
+++ b/cmd/copsctl/namespace.go
@@ -12,9 +12,7 @@ func createNamespaceCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "namespace",
 		Short: "Command group for administration of k8s namespaces",
-		Long: `
-Use this command to administer k8s namespaces.
-        `,
+		Long:  "Use this command to administer k8s namespaces.",
 		Run: func(cmd *cobra.Command, args []string) {
 			// since "namespace" is not really a command, but rather a group of commands, we
 			// show the help for the command group instead
@@ -26,6 +24,7 @@ Use this command to administer k8s namespaces.
 	}
 
 	command.AddCommand(createNamespaceCreateCommand())
+	command.AddCommand(createNamespaceUsersCommand())
 
 	command.PersistentFlags().StringP("name", "n", "", "Name of the namespace")
 	command.MarkPersistentFlagRequired("name")
@@ -37,9 +36,7 @@ func createNamespaceCreateCommand() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "create",
 		Short: "Create a new namespace",
-		Long: `
-Use this command to create a new k8s namespace.
-        `,
+		Long:  "Use this command to create a new k8s namespace.",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlag("users", cmd.Flags().Lookup("users"))
 			viper.BindPFlag("name", cmd.Flags().Lookup("name"))
@@ -51,5 +48,80 @@ Use this command to create a new k8s namespace.
 
 	command.PersistentFlags().StringP("users", "u", "", "The email-addresses of the admin users of the namespace. Must be identical to Azure AD (case-sensitive). You can specify multiple users separated by comma.")
 	command.MarkPersistentFlagRequired("users")
+	return command
+}
+
+func createNamespaceUsersCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "users",
+		Short: "Mange users of a namespace",
+		Long:  "Use this command to mange the users in an existing k8s namespace.",
+		Run: func(cmd *cobra.Command, args []string) {
+			// since "namespace" is not really a command, but rather a group of commands, we
+			// show the help for the command group instead
+			if len(args) == 0 {
+				cmd.Help()
+				os.Exit(0)
+			}
+		},
+	}
+
+	command.AddCommand(createNamespaceUsersAddCommand())
+	command.AddCommand(createNamespaceUsersRemoveCommand())
+	command.AddCommand(createNamespaceUsersListCommand())
+
+	return command
+}
+
+func createNamespaceUsersAddCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "add",
+		Short: "Adds users to the namespace",
+		Long:  "Use this command to add users to an existing k8s namespace.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("users", cmd.Flags().Lookup("users"))
+			viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace.AddUsers()
+		},
+	}
+
+	command.PersistentFlags().StringP("users", "u", "", "The email-addresses of the users that you want to add. Must be identical to Azure AD (case-sensitive). You can specify multiple users separated by comma.")
+	command.MarkPersistentFlagRequired("users")
+	return command
+}
+
+func createNamespaceUsersRemoveCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "remove",
+		Short: "Removes users from a namespace",
+		Long:  "Use this command to remove users from an existing k8s namespace.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("users", cmd.Flags().Lookup("users"))
+			viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace.RemoveUsers()
+		},
+	}
+
+	command.PersistentFlags().StringP("users", "u", "", "The email-addresses of the users that you want to remove from the namespace. Must be identical to Azure AD (case-sensitive). You can specify multiple users separated by comma.")
+	command.MarkPersistentFlagRequired("users")
+	return command
+}
+
+func createNamespaceUsersListCommand() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "list",
+		Short: "List users of a namespace",
+		Long:  "Use this command to list users of an existing k8s namespace.",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace.ListUsers()
+		},
+	}
 	return command
 }

--- a/cmd/copsctl/namespace.go
+++ b/cmd/copsctl/namespace.go
@@ -41,7 +41,7 @@ func createNamespaceCreateCommand() *cobra.Command {
 Use this command to create a new k8s namespace.
         `,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			viper.BindPFlag("user", cmd.Flags().Lookup("user"))
+			viper.BindPFlag("users", cmd.Flags().Lookup("users"))
 			viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -49,7 +49,7 @@ Use this command to create a new k8s namespace.
 		},
 	}
 
-	command.PersistentFlags().StringP("user", "u", "", "The email-address of the admin user of the namespace. Must be identical to Azure AD (case-sensitive).")
-	command.MarkPersistentFlagRequired("user")
+	command.PersistentFlags().StringP("users", "u", "", "The email-addresses of the admin users of the namespace. Must be identical to Azure AD (case-sensitive). You can specify multiple users separated by comma.")
+	command.MarkPersistentFlagRequired("users")
 	return command
 }

--- a/pkg/adapters/kubernetes/commands.go
+++ b/pkg/adapters/kubernetes/commands.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/conplementAG/copsctl/pkg/common/commands"
+	"github.com/conplementAG/copsctl/pkg/common/fileprocessing"
 )
 
 // UseContext sets the given context as the current context in the config file
@@ -23,10 +24,25 @@ func GetCurrentConfig() *ConfigResponse {
 	return config
 }
 
+// GetCopsNamespace gets the given CopsNamespace
+func GetCopsNamespace(namespace string) *CopsNamespaceResponse {
+	command := "kubectl get CopsNamespace " + namespace + " -o json"
+	out := commands.ExecuteCommand(commands.Create(command))
+	response := &CopsNamespaceResponse{}
+	json.Unmarshal([]byte(out), &response)
+	return response
+}
+
 func Apply(filepath string) string {
 	command := "kubectl apply -f " + filepath
 	data := commands.ExecuteCommandLongRunning(commands.Create(command))
 	return data
+}
+
+func ApplyString(content string) {
+	temporaryDirectory, temporaryFile := fileprocessing.WriteStringToTemporaryFile(content, "resource.yaml")
+	Apply(temporaryFile)
+	fileprocessing.DeletePath(temporaryDirectory)
 }
 
 func CanIGetPods(namespace string) bool {

--- a/pkg/adapters/kubernetes/copsnamespace.go
+++ b/pkg/adapters/kubernetes/copsnamespace.go
@@ -1,0 +1,12 @@
+package kubernetes
+
+type CopsNamespaceResponse struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		NamespaceAdminUsers []string `yaml:"namespaceAdminUsers"`
+	} `yaml:"spec"`
+}

--- a/pkg/namespace/orchestrator.go
+++ b/pkg/namespace/orchestrator.go
@@ -1,11 +1,11 @@
 package namespace
 
 import (
+	"log"
 	"strings"
 	"time"
 
 	"github.com/conplementAG/copsctl/pkg/adapters/kubernetes"
-	"github.com/conplementAG/copsctl/pkg/common/fileprocessing"
 	"github.com/conplementAG/copsctl/pkg/common/logging"
 	"github.com/spf13/viper"
 )
@@ -18,13 +18,91 @@ func Create() {
 	users := parseUsernames(userNames)
 	copsnamespace := renderTemplate(namespaceName, users)
 
-	temporaryDirectory, temporaryFile := fileprocessing.WriteStringToTemporaryFile(copsnamespace, "copsnamespace.yaml")
-	kubernetes.Apply(temporaryFile)
-	fileprocessing.DeletePath(temporaryDirectory)
+	kubernetes.ApplyString(copsnamespace)
 
 	ensureNamespaceAccess(namespaceName)
 
 	logging.LogSuccessf("Cops namespace %s successfully created\n", namespaceName)
+}
+
+// AddUsers adds the given users to the clusters
+func AddUsers() {
+	namespaceName := viper.GetString("name")
+	users := viper.GetString("users")
+
+	newUsers := parseUsernames(users)
+	namespace := kubernetes.GetCopsNamespace(namespaceName)
+	relevantUsers := namespace.Spec.NamespaceAdminUsers
+
+	addedUserCount := 0
+
+	for _, newUser := range newUsers {
+		userAlreadyExists := false
+
+		for _, existingUser := range relevantUsers {
+			if existingUser == newUser {
+				userAlreadyExists = true
+				break
+			}
+		}
+
+		if !userAlreadyExists {
+			relevantUsers = append(relevantUsers, newUser)
+			addedUserCount++
+		}
+	}
+
+	copsnamespace := renderTemplate(namespaceName, relevantUsers)
+	kubernetes.ApplyString(copsnamespace)
+
+	logging.LogSuccessf("%d user(s) have been successfully added to %s namespace\n", addedUserCount, namespaceName)
+}
+
+// RemoveUsers removes the given users from the clusters
+func RemoveUsers() {
+	namespaceName := viper.GetString("name")
+	users := viper.GetString("users")
+
+	usersToRemove := parseUsernames(users)
+	namespace := kubernetes.GetCopsNamespace(namespaceName)
+	existingUsers := namespace.Spec.NamespaceAdminUsers
+	var relevantUsers []string
+
+	removedUserCount := 0
+
+	for _, existingUser := range existingUsers {
+		shouldUserBeRemoved := false
+
+		for _, userToRemove := range usersToRemove {
+			if userToRemove == existingUser {
+				shouldUserBeRemoved = true
+				removedUserCount++
+				break
+			}
+		}
+
+		if !shouldUserBeRemoved {
+			relevantUsers = append(relevantUsers, existingUser)
+		}
+	}
+
+	copsnamespace := renderTemplate(namespaceName, relevantUsers)
+	kubernetes.ApplyString(copsnamespace)
+
+	logging.LogSuccessf("%d user(s) have been successfully removed from %s namespace\n", removedUserCount, namespaceName)
+}
+
+// ListUsers prints the current users of the given namespace
+func ListUsers() {
+	namespaceName := viper.GetString("name")
+	namespace := kubernetes.GetCopsNamespace(namespaceName)
+	users := namespace.Spec.NamespaceAdminUsers
+
+	log.Println("Current users in namespace " + namespaceName + ":")
+
+	for _, user := range users {
+		log.Println(" - " + user)
+	}
 }
 
 func renderTemplate(namespaceName string, userNames []string) string {

--- a/pkg/namespace/template.go
+++ b/pkg/namespace/template.go
@@ -5,5 +5,5 @@ kind: CopsNamespace
 metadata:
   name: {{ namespaceName }}
 spec:
-  namespace-admin-users:
+  namespaceAdminUsers:
 {{ usernames }}`

--- a/pkg/namespace/template.go
+++ b/pkg/namespace/template.go
@@ -6,4 +6,4 @@ metadata:
   name: {{ namespaceName }}
 spec:
   namespace-admin-users:
-  - {{ adminUsername }}`
+{{ usernames }}`


### PR DESCRIPTION
# copsctl User Mangement

Adds support for the following commands:

```
copsctl namespace create -n myspace -u user1@company.com,user2@company.com
copsctl namespace users add -n myspace -u user1@company.com,user2@company.com
copsctl namespace users remove -n myspace -u user1@company.com,user2@company.com
copsctl namespace users list -n myspace
```

# ATTENTION

Please be aware that there is an **API Change** included, which must be handled in copscontroller.

`namespace-admin-users` -> `namespaceAdminUsers` in copsnamespace CRD.

This is because CamelCase is the kubernetes naming style and it is parsable by golang, which otherwise is not working.