### PR TITLE
[fix] extend tiller clusterrole 

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -17,7 +17,7 @@ rules:
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["monitoring.coreos.com"]
-  resources: ["servicemonitors"]
+  resources: ["servicemonitors", "prometheusrules"]
   verbs: ["*"]
 ---
 kind: RoleBinding


### PR DESCRIPTION
extend apigroup 'monitoring.coreos.com' with resource prometheusrules