### PR TITLE
Installation of copsctl via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ copsctl - the conplement AG Kubernetes developer tooling
 
 ## Installation
 
+### Manual Installation
 Simply download a binary for your target system from [Releases](https://github.com/conplementAG/copsctl/releases), set it to you PATH, and you are ready to go.
+
+### Homebrew (macOS and Linux)
+You can install copsctl using Homebrew:
+
+```bash
+brew tap conplementag/tap
+brew install copsctl
+```
+
+For more details, visit [conplementAG/homebrew-tap](https://github.com/conplementAG/homebrew-tap).
 
 ## Contributing
 


### PR DESCRIPTION
I created a [homebrew-tap](https://github.com/conplementAG/homebrew-tap) for copsctl so that installation via brew is enabled (and even tab-completion works OOTB! 😄 )

Updating the tap after a new release can and should be automated by calling the `release-pr` workflow in the above repo.
An example of how to dispatch a remote action can be found [here](https://github.com/databricks/cli/blob/56663613a8c115e5fbad96a9453888649b24a10c/.github/workflows/release.yml#L101)