### PR TITLE
ci: trigger homebrew-tap formula update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,26 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-homebrew-tap:
+    # Runs only after a successful release (goreleaser skipped -> this is skipped too).
+    needs: [goreleaser]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve released version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName | sed 's/^v//')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger homebrew-tap formula update
+        env:
+          # PAT/App token with "contents: write" on conplementAG/homebrew-tap.
+          # The default GITHUB_TOKEN cannot dispatch events to another repository.
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          gh api repos/conplementAG/homebrew-tap/dispatches \
+            -f event_type=copsctl-release \
+            -f "client_payload[version]=${{ steps.ver.outputs.version }}"


### PR DESCRIPTION
## Was

Ergänzt einen `bump-homebrew-tap`-Job in `release.yml`, der **nach erfolgreichem GoReleaser-Lauf** ein `repository_dispatch`-Event (`event_type: copsctl-release`) an [conplementAG/homebrew-tap](https://github.com/conplementAG/homebrew-tap) sendet. Der Tap aktualisiert die copsctl-Formel daraufhin automatisch (Version + Checksums werden tap-seitig aus `checksums.txt` aufgelöst) und mergt den PR per Auto-Merge.

- `needs: [goreleaser]` → der Job läuft nur, wenn tatsächlich ein Release gebaut wurde (bei übersprungenem GoReleaser wird auch dieser Job übersprungen). Die bestehende Gating-Logik bleibt unangetastet.
- Versionsauflösung via `gh release view` mit dem Standard-`GITHUB_TOKEN`; der Cross-Repo-Dispatch nutzt ein separates Token.

## Voraussetzung (vor dem Mergen einrichten)

- Repository-Secret **`HOMEBREW_TAP_TOKEN`**: Fine-grained PAT (oder GitHub-App-Token) mit `contents: write` auf `conplementAG/homebrew-tap`. Der Default-`GITHUB_TOKEN` kann keine Events an ein anderes Repo dispatchen.

## Abhängigkeit

Gehört zum gegenstückigen Tap-PR (Listener `repository_dispatch: copsctl-release` + Auto-Merge). Der Tap-PR sollte zuerst gemergt werden.